### PR TITLE
V2018.1.x: Fixed build problem.

### DIFF
--- a/templates/dus/prepare.sh
+++ b/templates/dus/prepare.sh
@@ -2,7 +2,7 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 
 

--- a/templates/duskey/prepare.sh
+++ b/templates/duskey/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/dusl2tp/prepare.sh
+++ b/templates/dusl2tp/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/dusl2tpkey/prepare.sh
+++ b/templates/dusl2tpkey/prepare.sh
@@ -2,7 +2,7 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 
 

--- a/templates/erk-key/prepare.sh
+++ b/templates/erk-key/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/erk/prepare.sh
+++ b/templates/erk/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/han-key/prepare.sh
+++ b/templates/han-key/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/han/prepare.sh
+++ b/templates/han/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/hld-key/prepare.sh
+++ b/templates/hld-key/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/hld/prepare.sh
+++ b/templates/hld/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/hlg-key/prepare.sh
+++ b/templates/hlg-key/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/hlg/prepare.sh
+++ b/templates/hlg/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/lgf-key/prepare.sh
+++ b/templates/lgf-key/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/lgf/prepare.sh
+++ b/templates/lgf/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/lvr-key/prepare.sh
+++ b/templates/lvr-key/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/lvr/prepare.sh
+++ b/templates/lvr/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/met-key/prepare.sh
+++ b/templates/met-key/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/met/prepare.sh
+++ b/templates/met/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/mon-key/prepare.sh
+++ b/templates/mon-key/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/mon/prepare.sh
+++ b/templates/mon/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/rat-key/prepare.sh
+++ b/templates/rat-key/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/rat/prepare.sh
+++ b/templates/rat/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/vel-key/prepare.sh
+++ b/templates/vel-key/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/vel/prepare.sh
+++ b/templates/vel/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 

--- a/templates/wlf/prepare.sh
+++ b/templates/wlf/prepare.sh
@@ -2,6 +2,6 @@
 # git apply $(dirname $0)/keepradiochannel.diff
 # echo "CONFIG_PATA_ATIIXP=y" >> openwrt/target/linux/x86/generic/config-default
  
-cp ../patches/sysupgrade ./lede/package/base-files/files/sbin/sysupgrade
-chmod +x ./lede/package/base-files/files/sbin/sysupgrade
+cp ../patches/sysupgrade ./openwrt/package/base-files/files/sbin/sysupgrade
+chmod +x ./openwrt/package/base-files/files/sbin/sysupgrade
 


### PR DESCRIPTION
Ich bin neu bei Freifunk, meine E-Mail-Adresse lautet rdiez at neanderfunk.de .

Mir wurde erzählt, dass das build.sh Build-Skript nicht gut funktioniert hat. Ich habe dieses Skript bei mir so gut wie neu geschrieben. Das alte Skript hatte nämlich keine Fehlerbehandlung und man hat nicht leicht gesehen, warum das Build gescheitert ist.

Mit dem neuen Skript habe ich gemerkt, ist dass alle "./lede/package/..." Pfade in den prepare.sh Dateien falsch sind. Das Lede Projekt hat sich nämlich wieder mit OpenWrt zusammengetan, und jetzt heißt das alles nur noch OpenWrt. Das habe ich bei mir auch behoben.

Danach funktioniert das Skript wieder, zu mindest für die wenige Sites, die ich getestet habe. Der Build-Prozess ist leider zu langsam für meinen Laptop.

Ich würde die Sites (die ganzen Dateien wie prepare.sh) automatisch generieren. Aber zuerst möchte ich wissen, warum nicht alle gleich sind. Zum Beispiel, diese 2 sind unterschiedlich:

https://github.com/eulenfunk/firmware/blob/v2018.1.x/templates/wlf-key/prepare.sh

https://github.com/eulenfunk/firmware/blob/v2018.1.x/templates/vel-key/prepare.sh
